### PR TITLE
Self AQUEeANEA

### DIFF
--- a/handler/MenuHandler.py
+++ b/handler/MenuHandler.py
@@ -55,12 +55,14 @@ class MenuHandler:
 
 			# the choice is the number displayed before the print of every the AQUE respose,
 			# the user will use this number to select the file to download
-			AppData.get_peer_file_by_index(file_index)
+			peer_file = AppData.get_peer_file_by_index(file_index)
 
+			AppData.set_file_download(peer_file[4])
 
 			# After user'choice the peer_file list must be cleaned,
 			# so when the next QUER will send,the list can be repopulated
 			AppData.clear_peer_files()
+			AppData.clear_file_dowload()
 
 		elif choice == "NEAR":
 			pass

--- a/handler/MenuHandler.py
+++ b/handler/MenuHandler.py
@@ -5,6 +5,8 @@ from service.Server import Server
 from threading import Timer
 import socket
 from multiprocessing import Process
+from service.AppData import AppData
+
 
 
 class MenuHandler:
@@ -47,7 +49,18 @@ class MenuHandler:
 				t.cancel()
 				self.__kill_server(p)
 
-			choice = input('Please select a peer:')
+			file_index = input('Please select a file:')
+
+			# INSERIRE IL CODICE DELLA RETR
+
+			# the choice is the number displayed before the print of every the AQUE respose,
+			# the user will use this number to select the file to download
+			AppData.get_peer_file_by_index(file_index)
+
+
+			# After user'choice the peer_file list must be cleaned,
+			# so when the next QUER will send,the list can be repopulated
+			AppData.clear_peer_files()
 
 		elif choice == "NEAR":
 			pass

--- a/handler/SelfHandler.py
+++ b/handler/SelfHandler.py
@@ -26,7 +26,7 @@ class SelfHandler(HandlerInterface):
 			ip4_peer, ip6_peer = ip_utils.get_ip_pair(ip_peer)
 			port_peer = request[75:80]
 			filemd5 = request[80:112]
-			filename = request[112:212].decode('UTF-8').lower().lstrip().rstrip()
+			filename = request[112:212].lower().lstrip().rstrip()
 
 			if not AppData.exist_packet(pktid):
 				AppData.add_packet(pktid, ip_peer, port_peer)
@@ -34,7 +34,9 @@ class SelfHandler(HandlerInterface):
 			if not AppData.exist_peer_files((ip4_peer, ip6_peer, port_peer, filemd5, filename)):
 				AppData.add_peer_files((ip4_peer, ip6_peer, port_peer, filemd5, filename))
 
-			print(f'Response from {ip4_peer}|{ip6_peer} port {port_peer} --> File: {filename} MD5: {filemd5}')
+			index = AppData.peer_file_index((ip4_peer, ip6_peer, port_peer, filemd5, filename))
+
+			print(f'{index})   Response from {ip4_peer}|{ip6_peer} port {port_peer} --> File: {filename} MD5: {filemd5}')
 
 
 		elif command == "ANEA":

--- a/handler/SelfHandler.py
+++ b/handler/SelfHandler.py
@@ -30,7 +30,7 @@ class SelfHandler(HandlerInterface):
 
 
 			if len(response) != 208:
-				return "Invalid response. Expected: AQUE<pkt_id><ip_peer><port_peer><fileMD5><filename>"
+				return "Invalid response. Expected: AQUE<pkt_id><ip_peer><port_peer><fileMD5><filename>\nFrom the socket:" + command + response
 
 			pktid = response[0:16]
 			ip_peer = response[16:71]
@@ -58,7 +58,7 @@ class SelfHandler(HandlerInterface):
 					print(f'Unable to read the {command} response from the socket\n OSError: {e}')
 
 			if len(response) != 76:
-				return "Invalid response. Expected: ANEA<pkt_id><ip_peer><port_peer>"
+				return "Invalid response. Expected: ANEA<pkt_id><ip_peer><port_peer>\nFrom the socket:" + command + response
 
 			pktid = response[0:16]
 			ip_peer = response[16:71]
@@ -79,5 +79,10 @@ class SelfHandler(HandlerInterface):
 			#	return "Invalid response. Expected: ARET<#chunks>{<chunk_lenght(i)><data(i)>} for i=1,2,...,#chunks"
 
 			Downloader.start(sd, AppData.get_file_download())
+
+		else:
+			wrong_response = sd.recv(300).decode()
+
+			return "Invalid response.\nFrom the socket:" + command + wrong_response
 
 		sd.close()

--- a/handler/SelfHandler.py
+++ b/handler/SelfHandler.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import socket
+from utils import ip_utils
+from service.AppData import AppData
 from handler.HandlerInterface import HandlerInterface
 
 
@@ -16,12 +18,48 @@ class SelfHandler(HandlerInterface):
 		command = request[:4]
 
 		if command == "AQUE":
-			pass
+			if len(request) != 212:
+				return "Invalid response. Expected: AQUE<pkt_id><ip_peer><port_peer><fileMD5><filename>"
+
+			pktid = request[4:20]
+			ip_peer = request[20:75]
+			ip4_peer, ip6_peer = ip_utils.get_ip_pair(ip_peer)
+			port_peer = request[75:80]
+			filemd5 = request[80:112]
+			filename = request[112:212].decode('UTF-8').lower().lstrip().rstrip()
+
+			AppData.add_packet(pktid, ip_peer, port_peer)
+
+			AppData.add_peer_files((ip4_peer, ip6_peer, port_peer, filemd5, filename))
+
+			print(f'Response from {ip4_peer}|{ip6_peer} port {port_peer} --> File: {filename} MD5: {filemd5}')
+
 
 		elif command == "ANEA":
-			pass
+			if len(request) != 80:
+				return "Invalid response. Expected: ANEA<pkt_id><ip_peer><port_peer>"
+
+			pktid = request[4:20]
+			ip_peer = request[20:75]
+			ip4_peer, ip6_peer = ip_utils.get_ip_pair(ip_peer)
+			port_peer = request[75:80]
+
+		if not AppData.exist_packet(pktid):
+			AppData.add_packet(pktid, ip_peer, port_peer)
+
+			#memorizza pacchetto
+
+			#memorizza vicini
+
+			#mostra vicini
 
 		elif command == "ARET":
 			pass
+
+			#memorizza pacchetto
+
+			#ricevi pacchetto via socket
+
+			#leggi pacchetto
 
 		sd.close()

--- a/handler/SelfHandler.py
+++ b/handler/SelfHandler.py
@@ -28,9 +28,11 @@ class SelfHandler(HandlerInterface):
 			filemd5 = request[80:112]
 			filename = request[112:212].decode('UTF-8').lower().lstrip().rstrip()
 
-			AppData.add_packet(pktid, ip_peer, port_peer)
+			if not AppData.exist_packet(pktid):
+				AppData.add_packet(pktid, ip_peer, port_peer)
 
-			AppData.add_peer_files((ip4_peer, ip6_peer, port_peer, filemd5, filename))
+			if not AppData.exist_peer_files((ip4_peer, ip6_peer, port_peer, filemd5, filename)):
+				AppData.add_peer_files((ip4_peer, ip6_peer, port_peer, filemd5, filename))
 
 			print(f'Response from {ip4_peer}|{ip6_peer} port {port_peer} --> File: {filename} MD5: {filemd5}')
 
@@ -44,14 +46,13 @@ class SelfHandler(HandlerInterface):
 			ip4_peer, ip6_peer = ip_utils.get_ip_pair(ip_peer)
 			port_peer = request[75:80]
 
-		if not AppData.exist_packet(pktid):
-			AppData.add_packet(pktid, ip_peer, port_peer)
+			if not AppData.exist_packet(pktid):
+				AppData.add_packet(pktid, ip_peer, port_peer)
 
-			#memorizza pacchetto
+			if not AppData.is_neighbour((ip4_peer,ip6_peer,port_peer)):
+				AppData.add_neighbour((ip4_peer,ip6_peer,port_peer))
 
-			#memorizza vicini
-
-			#mostra vicini
+			print(f'New neighbour founded: {ip4_peer}|{ip6_peer} port {port_peer}')
 
 		elif command == "ARET":
 			pass

--- a/handler/SelfHandler.py
+++ b/handler/SelfHandler.py
@@ -4,6 +4,7 @@ import socket
 from utils import ip_utils
 from service.AppData import AppData
 from handler.HandlerInterface import HandlerInterface
+from service.Downloader import Downloader
 
 
 class SelfHandler(HandlerInterface):
@@ -57,12 +58,9 @@ class SelfHandler(HandlerInterface):
 			print(f'New neighbour founded: {ip4_peer}|{ip6_peer} port {port_peer}')
 
 		elif command == "ARET":
-			pass
+			if len(request) <= 15:
+				return "Invalid response. Expected: ARET<#chunks>{<chunk_lenght(i)><data(i)>} for i=1,2,...,#chunks"
 
-			#memorizza pacchetto
-
-			#ricevi pacchetto via socket
-
-			#leggi pacchetto
+			Downloader.start(sd, AppData.get_file_download())
 
 		sd.close()

--- a/handler/SelfHandler.py
+++ b/handler/SelfHandler.py
@@ -24,7 +24,7 @@ class SelfHandler(HandlerInterface):
 		if command == "AQUE":
 
 			try:
-				response = sd.recv(208).decode()
+				response = sd.recv(250).decode()
 			except OSError as e:
 					print(f'Unable to read the {command} response from the socket\n OSError: {e}')
 
@@ -39,13 +39,10 @@ class SelfHandler(HandlerInterface):
 			filemd5 = response[76:108]
 			filename = response[108:208].lower().lstrip().rstrip()
 
-			if not AppData.exist_packet(pktid):
-				AppData.add_packet(pktid, ip_peer, port_peer)
+			if not AppData.exist_peer_files(ip4_peer, ip6_peer, port_peer, filemd5, filename):
+				AppData.add_peer_files(ip4_peer, ip6_peer, port_peer, filemd5, filename)
 
-			if not AppData.exist_peer_files((ip4_peer, ip6_peer, port_peer, filemd5, filename)):
-				AppData.add_peer_files((ip4_peer, ip6_peer, port_peer, filemd5, filename))
-
-			index = AppData.peer_file_index((ip4_peer, ip6_peer, port_peer, filemd5, filename))
+			index = AppData.peer_file_index(ip4_peer, ip6_peer, port_peer, filemd5, filename)
 
 			print(f'{index})   Response from {ip4_peer}|{ip6_peer} port {port_peer} --> File: {filename} MD5: {filemd5}')
 
@@ -65,20 +62,10 @@ class SelfHandler(HandlerInterface):
 			ip4_peer, ip6_peer = ip_utils.get_ip_pair(ip_peer)
 			port_peer = response[71:76]
 
-			if not AppData.exist_packet(pktid):
-				AppData.add_packet(pktid, ip_peer, port_peer)
+			if not AppData.is_neighbour(ip4_peer, ip6_peer, port_peer):
+				AppData.add_neighbour(ip4_peer, ip6_peer, port_peer)
 
-			if not AppData.is_neighbour((ip4_peer,ip6_peer,port_peer)):
-				AppData.add_neighbour((ip4_peer,ip6_peer,port_peer))
-
-			print(f'New neighbour founded: {ip4_peer}|{ip6_peer} port {port_peer}')
-
-		elif command == "ARET":
-
-			#if len(request) <= 15:
-			#	return "Invalid response. Expected: ARET<#chunks>{<chunk_lenght(i)><data(i)>} for i=1,2,...,#chunks"
-
-			Downloader.start(sd, AppData.get_file_download())
+			print(f'New neighbour found: {ip4_peer}|{ip6_peer} port {port_peer}')
 
 		else:
 			wrong_response = sd.recv(300).decode()

--- a/service/AppData.py
+++ b/service/AppData.py
@@ -14,6 +14,7 @@ class AppData:
 	# ('ipv4', 'ipv6', 'port)
 	neighbours = list()
 
+	# (ip4_peer, ip6_peer, port_peer, filemd5, filename)
 	peer_files = list()
 
 	# received packet management --------------------------------------------------
@@ -60,4 +61,14 @@ class AppData:
 	@classmethod
 	def get_peer_port(cls, peer: tuple) -> str:
 		return peer[2]
+	# -----------------------------------------------------------------------------
+
+	# peer_files management--------------------------------------------------------------
+	@classmethod
+	def add_peer_files(cls, peer_file: tuple) -> None:
+		cls.peer_files.append(peer_file)
+
+	@classmethod
+	def exist_peer_files(cls, peer_file: tuple) -> bool:
+		return peer_file in cls.peer_files
 	# -----------------------------------------------------------------------------

--- a/service/AppData.py
+++ b/service/AppData.py
@@ -17,6 +17,7 @@ class AppData:
 	# ('ipv4', 'ipv6', 'port', 'md5', 'filename')
 	peer_files = list()
 
+	file_download: str
 	# received packet management --------------------------------------------------
 	@classmethod
 	def add_packet(cls, pktid: str, ip_peer: str, port_peer: str) -> None:
@@ -86,4 +87,18 @@ class AppData:
 	@classmethod
 	def clear_peer_files(cls) -> None:
 		cls.peer_files.clear()
+	# -----------------------------------------------------------------------------
+
+	# file download management--------------------------------------------------------
+	@classmethod
+	def get_file_download(cls) -> str:
+		return cls.file_download
+
+	@classmethod
+	def set_file_download(cls, filename: str) -> None:
+		cls.file_download = filename
+
+	@classmethod
+	def clear_file_dowload(cls) -> None:
+		cls.file_download = None
 	# -----------------------------------------------------------------------------

--- a/service/AppData.py
+++ b/service/AppData.py
@@ -48,11 +48,11 @@ class AppData:
 
 	# peer list management --------------------------------------------------------
 	@classmethod
-	def is_neighbour(cls, peer: tuple) -> bool:
-		return peer in cls.neighbours
+	def is_neighbour(cls, ip4_peer: str, ip6_peer: str,port_peer: str) -> bool:
+		return (ip4_peer,ip6_peer,port_peer) in cls.neighbours
 
-	def add_neighbour(cls, peer: tuple) -> None:
-		cls.neighbours.append(peer)
+	def add_neighbour(cls, ip4_peer: str, ip6_peer: str,port_peer: str) -> None:
+		cls.neighbours.append((ip4_peer, ip6_peer, port_peer))
 
 	@classmethod
 	def get_peer_ip4(cls, peer: tuple) -> str:
@@ -69,16 +69,16 @@ class AppData:
 
 	# peer_files management--------------------------------------------------------
 	@classmethod
-	def add_peer_files(cls, peer_file: tuple) -> None:
-		cls.peer_files.append(peer_file)
+	def add_peer_files(cls, ip4_peer: str, ip6_peer: str, port_peer: str, filemd5: str, filename: str) -> None:
+		cls.peer_files.append((ip4_peer, ip6_peer, port_peer, filemd5, filename))
 
 	@classmethod
-	def exist_peer_files(cls, peer_file: tuple) -> bool:
-		return peer_file in cls.peer_files
+	def exist_peer_files(cls, ip4_peer: str, ip6_peer: str, port_peer: str, filemd5: str, filename: str) -> bool:
+		return (ip4_peer, ip6_peer, port_peer, filemd5, filename) in cls.peer_files
 
 	@classmethod
-	def peer_file_index(cls, peer_file: tuple) -> int:
-		return  cls.peer_files.index(peer_file)
+	def peer_file_index(cls, ip4_peer: str, ip6_peer: str, port_peer: str, filemd5: str, filename: str) -> int:
+		return cls.peer_files.index((ip4_peer, ip6_peer, port_peer, filemd5, filename))
 
 	@classmethod
 	def get_peer_file_by_index(cls, index: int) -> tuple:

--- a/service/AppData.py
+++ b/service/AppData.py
@@ -14,7 +14,7 @@ class AppData:
 	# ('ipv4', 'ipv6', 'port)
 	neighbours = list()
 
-	# (ip4_peer, ip6_peer, port_peer, filemd5, filename)
+	# (ipv4, ipv6, port, md5, filename)
 	peer_files = list()
 
 	# received packet management --------------------------------------------------
@@ -49,6 +49,9 @@ class AppData:
 	@classmethod
 	def is_neighbour(cls, peer: tuple) -> bool:
 		return peer in cls.neighbours
+
+	def add_neighbour(cls, peer: tuple) -> None:
+		cls.neighbours.append(peer)
 
 	@classmethod
 	def get_peer_ip4(cls, peer: tuple) -> str:

--- a/service/AppData.py
+++ b/service/AppData.py
@@ -14,7 +14,7 @@ class AppData:
 	# ('ipv4', 'ipv6', 'port)
 	neighbours = list()
 
-	# (ipv4, ipv6, port, md5, filename)
+	# ('ipv4', 'ipv6', 'port', 'md5', 'filename')
 	peer_files = list()
 
 	# received packet management --------------------------------------------------
@@ -66,7 +66,7 @@ class AppData:
 		return peer[2]
 	# -----------------------------------------------------------------------------
 
-	# peer_files management--------------------------------------------------------------
+	# peer_files management--------------------------------------------------------
 	@classmethod
 	def add_peer_files(cls, peer_file: tuple) -> None:
 		cls.peer_files.append(peer_file)
@@ -74,4 +74,16 @@ class AppData:
 	@classmethod
 	def exist_peer_files(cls, peer_file: tuple) -> bool:
 		return peer_file in cls.peer_files
+
+	@classmethod
+	def peer_file_index(cls, peer_file: tuple) -> int:
+		return  cls.peer_files.index(peer_file)
+
+	@classmethod
+	def get_peer_file_by_index(cls, index: int) -> tuple:
+		return cls.peer_files.pop(index)
+
+	@classmethod
+	def clear_peer_files(cls) -> None:
+		cls.peer_files.clear()
 	# -----------------------------------------------------------------------------


### PR DESCRIPTION
Aggiornata la PR, 
ora il SelfHandler legge direttamente dalla socket il comando e solo dopo averlo determinato continua a leggere la response. Mentre nel caso della ARET passa la socket al Downloader (@jhonrambo93 ) che riprenderà la lettura direttamente dal numero di chunks.

Non ho toccato la classe Server.py ne il metodo __child(); 
visto che ci saranno un botto di conflitti non voglio crearne altri evitabili, quindi io o @NicFontana decidiamo chi la modifica.

8u0n4 P45qu3ll4



**************************************************OLD********************************************************
SelfHandler come è stato progettato è finito.

Ho aggiunto metodi e variabili di servizio in AppData.

Alcuni di questi gli ho inseriti anche in MenuHandler, come traccia delle cose che mi servono per Fede,
quindi FEDE dacci un'occhio, implementali nel tuo Handler e cerchiamo di non perderli nel momento in cui andremo a mergiare.

N.B. Ho una questione che necessita discussioni: nella classe Server.py, il metodo che descrive il codice del figlio __child() effettua una lettura dalla socket, e passa la risposta al metodo dell'interfaccia handler.serve().
Così facendo, in NeighbourHandler e SelfHandler la prima operazione che si fa è il controllo del tipo di comando.
Detto ciò, secondo me il __child non dovrebbe fare nessuna lettura. questo perchè all'interno della "ARET" nel self handler io devo passare una socket da cui il Downloader deve leggere dei dati, ma se la primma parte di quei dati viene letta in modo casuale iil downloader non è più in grado di leggere con un ciclo i dati.
***************************************************************************************************************